### PR TITLE
Svelte HMR Implemented

### DIFF
--- a/src/build/compileSvelte.ts
+++ b/src/build/compileSvelte.ts
@@ -125,68 +125,15 @@ export const compileSvelte = async (
 			mkdir(dirname(clientPath), { recursive: true })
 		]);
 
-		// Generate HMR ID from relative file path
-		const hmrId = relative(svelteRoot, src)
-			.replace(/\\/g, '/')
-			.replace(/\.svelte(\.(ts|js))?$/, '');
-
-		// HMR wrapper for client components
-		const wrapWithHMR = (code: string) => {
-			if (!dev) return code;
-			return `${code}
-
-// Svelte HMR - accept updates and re-mount component
-if (typeof import.meta !== "undefined" && import.meta.hot) {
-  import.meta.hot.accept(async (newModule) => {
-    if (newModule && newModule.default && typeof window !== "undefined") {
-      console.log('[HMR] Svelte component updated:', ${JSON.stringify(hmrId)});
-      // Store props before destroying
-      const currentProps = window.__SVELTE_PROPS__ || window.__INITIAL_PROPS__ || {};
-      // Destroy old component if it exists
-      if (window.__SVELTE_COMPONENT__) {
-        try {
-          // Svelte 5 uses unmount, Svelte 4 uses $destroy
-          if (typeof window.__SVELTE_COMPONENT__.unmount === 'function') {
-            window.__SVELTE_COMPONENT__.unmount();
-          } else if (typeof window.__SVELTE_COMPONENT__.$destroy === 'function') {
-            window.__SVELTE_COMPONENT__.$destroy();
-          }
-        } catch (e) {
-          console.warn('[HMR] Error destroying old component:', e);
-        }
-      }
-      // Mount new component with preserved props
-      try {
-        const { mount } = await import('svelte');
-        window.__SVELTE_COMPONENT__ = mount(newModule.default, {
-          target: document.body,
-          props: currentProps
-        });
-        window.__SVELTE_PROPS__ = currentProps;
-        console.log('[HMR] Svelte component re-mounted with preserved state');
-      } catch (e) {
-        console.warn('[HMR] Error mounting new component:', e);
-        window.location.reload();
-      }
-    }
-  });
-}`;
-		};
-
 		if (isModule) {
 			const bundle = generate('client');
-			const clientBundleWithHMR = wrapWithHMR(bundle);
-			await Promise.all([
-				write(ssrPath, bundle),
-				write(clientPath, clientBundleWithHMR)
-			]);
+			await Promise.all([write(ssrPath, bundle), write(clientPath, bundle)]);
 		} else {
 			const serverBundle = generate('server');
 			const clientBundle = generate('client');
-			const clientBundleWithHMR = wrapWithHMR(clientBundle);
 			await Promise.all([
 				write(ssrPath, serverBundle),
-				write(clientPath, clientBundleWithHMR)
+				write(clientPath, clientBundle)
 			]);
 		}
 
@@ -213,62 +160,34 @@ if (typeof import.meta !== "undefined" && import.meta.hot) {
 			const hmrImports = isDev
 				? `window.__HMR_FRAMEWORK__ = "svelte";\nimport "${hmrClientPath}";\n`
 				: '';
-			const bootstrap = `${hmrImports}import C from "${importPath}";
-import { hydrate, mount } from "svelte";
-// HMR State Preservation: Check for preserved state and merge with initial props
-const preservedState = (typeof window !== "undefined" && window.__HMR_PRESERVED_STATE__) ? window.__HMR_PRESERVED_STATE__ : {};
-const mergedProps = { ...(window.__INITIAL_PROPS__ ?? {}), ...preservedState };
-console.log('📦 Svelte index: mergedProps =', JSON.stringify(mergedProps));
-// Clear preserved state after using it
-if (typeof window !== "undefined") {
+			const bootstrap = `${hmrImports}import Component from "${importPath}";
+import { hydrate, mount, unmount } from "svelte";
+
+var initialProps = (typeof window !== "undefined" && window.__INITIAL_PROPS__) ? window.__INITIAL_PROPS__ : {};
+var isHMR = typeof window !== "undefined" && window.__SVELTE_COMPONENT__ !== undefined;
+var component;
+
+if (isHMR) {
+  if (typeof window.__SVELTE_UNMOUNT__ === "function") {
+    try { window.__SVELTE_UNMOUNT__(); } catch (err) { console.warn("[HMR] unmount error:", err); }
+  }
+  var preservedState = window.__HMR_PRESERVED_STATE__;
+  if (!preservedState) {
+    try {
+      var stored = sessionStorage.getItem("__SVELTE_HMR_STATE__");
+      if (stored) preservedState = JSON.parse(stored);
+    } catch (err) { /* ignore */ }
+  }
+  var mergedProps = preservedState ? Object.assign({}, initialProps, preservedState) : initialProps;
+  component = mount(Component, { target: document.body, props: mergedProps });
   window.__HMR_PRESERVED_STATE__ = undefined;
-}
-// Check if this is an HMR update (flag set by client HMR handler)
-const isHMRUpdate = typeof window !== 'undefined' && window.__SVELTE_HMR_UPDATE__ === true;
-console.log('📦 Svelte index: isHMRUpdate =', isHMRUpdate);
-// Clear HMR update flag
-if (typeof window !== 'undefined') {
-  window.__SVELTE_HMR_UPDATE__ = false;
-}
-// For HMR updates: Use clone overlay + forced reflow (guaranteed zero flicker)
-// For initial load: use hydrate() to attach to server-rendered HTML
-let component;
-if (isHMRUpdate) {
-  // Step 1: Clone current content (keeps it visible)
-  const bodyClone = document.body.cloneNode(true);
-  bodyClone.style.position = 'fixed';
-  bodyClone.style.top = '0';
-  bodyClone.style.left = '0';
-  bodyClone.style.width = '100%';
-  bodyClone.style.height = '100%';
-  bodyClone.style.zIndex = '99999';
-  bodyClone.style.pointerEvents = 'none';
-  bodyClone.style.background = window.getComputedStyle(document.body).background || '#fff';
-  document.body.appendChild(bodyClone);
-  
-  // Step 2: Mount new component off-screen
-  const offscreenContainer = document.createElement('div');
-  component = mount(C, { target: offscreenContainer, props: mergedProps });
-  const newChildren = Array.from(offscreenContainer.childNodes);
-  
-  // Step 3: Replace body children (happens under the clone)
-  const oldChildren = Array.from(document.body.childNodes).filter(child => child !== bodyClone);
-  oldChildren.forEach(child => child.remove());
-  newChildren.forEach(child => document.body.insertBefore(child, bodyClone));
-  
-  // Step 4: Force reflow to ensure new content is painted
-  document.body.offsetHeight;
-  
-  // Step 5: Remove clone to reveal new content (already painted)
-  bodyClone.remove();
 } else {
-  // Initial load: hydrate server-rendered HTML
-  component = hydrate(C, { target: document.body, props: mergedProps });
+  component = hydrate(Component, { target: document.body, props: initialProps });
 }
-console.log('✅ Svelte component', isHMRUpdate ? 'mounted' : 'hydrated', 'with props:', JSON.stringify(mergedProps));
-// Store component instance for future HMR updates
+
 if (typeof window !== "undefined") {
   window.__SVELTE_COMPONENT__ = component;
+  window.__SVELTE_UNMOUNT__ = function() { unmount(component); };
 }`;
 
 			await mkdir(dirname(indexPath), { recursive: true });

--- a/src/dev/client/types.ts
+++ b/src/dev/client/types.ts
@@ -84,13 +84,8 @@ declare global {
 		__HMR_WS__?: WebSocket;
 		__INITIAL_PROPS__?: Record<string, unknown>;
 		__REACT_ROOT__?: { render: (element: unknown) => void };
-		__SVELTE_COMPONENT__?: {
-			$destroy?: () => void;
-			unmount?: () => void;
-			[key: string]: unknown;
-		};
-		__SVELTE_HMR_UPDATE__?: boolean;
-		__SVELTE_PROPS__?: Record<string, unknown>;
+		__SVELTE_COMPONENT__?: Record<string, unknown>;
+		__SVELTE_UNMOUNT__?: () => void;
 		__VUE_APP__?:
 			| ({
 					unmount: () => void;

--- a/src/dev/rebuildTrigger.ts
+++ b/src/dev/rebuildTrigger.ts
@@ -846,10 +846,7 @@ export const triggerRebuild = async (
 								state.resolvedPaths.buildDir
 							);
 
-							// Get component info
-							const { basename, relative } = await import(
-								'node:path'
-							);
+							const { basename } = await import('node:path');
 							const { toPascal } = await import(
 								'../utils/stringModifiers'
 							);
@@ -857,30 +854,15 @@ export const triggerRebuild = async (
 							const baseName = fileName.replace(/\.svelte$/, '');
 							const pascalName = toPascal(baseName);
 
-							// Calculate HMR ID (relative path without .svelte extension, matches compileSvelte.ts)
-							const svelteRoot = config.svelteDirectory;
-							const hmrId = svelteRoot
-								? relative(svelteRoot, sveltePagePath)
-										.replace(/\\/g, '/')
-										.replace(/\.svelte$/, '')
-								: baseName;
-
-							// Get client module URL from manifest for official HMR
-							const clientKey = `${pascalName}Client`;
-							const clientModuleUrl = manifest[clientKey] || null;
-
 							// Get CSS URL from manifest
 							const cssKey = `${pascalName}CSS`;
 							const cssUrl = manifest[cssKey] || null;
 
 							logger.hmrUpdate(sveltePagePath, 'svelte');
-							// Send Svelte update with official HMR data
 							broadcastToClients(state, {
 								data: {
 									framework: 'svelte',
-									html: newHTML, // Fallback HTML if official HMR fails
-									hmrId,
-									clientModuleUrl, // Official HMR: client module to import
+									html: newHTML,
 									cssUrl,
 									cssBaseName: baseName,
 									updateType: 'full',

--- a/src/dev/types/messages.ts
+++ b/src/dev/types/messages.ts
@@ -117,6 +117,9 @@ export type SvelteUpdateMessage = {
     sourceFile: string;
     html?: string;
     manifest?: Record<string, string>;
+    cssUrl?: string;
+    cssBaseName?: string;
+    updateType?: string;
   };
   timestamp: number;
 };

--- a/src/dev/types/window-globals.ts
+++ b/src/dev/types/window-globals.ts
@@ -31,14 +31,10 @@ declare global {
 		__HMR_UPDATE_COUNT__?: number;
 
 		/* Svelte component instance */
-		__SVELTE_COMPONENT__?: {
-			$destroy?: () => void;
-			unmount?: () => void;
-			[key: string]: unknown;
-		};
+		__SVELTE_COMPONENT__?: Record<string, unknown>;
 
-		/* Flag to indicate Svelte HMR update in progress */
-		__SVELTE_HMR_UPDATE__?: boolean;
+		/* Svelte unmount function (closure over current runtime + component) */
+		__SVELTE_UNMOUNT__?: () => void;
 
 		/* WebSocket instance for HMR */
 		__HMR_WS__?: WebSocket;


### PR DESCRIPTION
# Svelte HMR Support

## Summary

- Adds hot module replacement for Svelte components with state preservation, CSS-only swaps, and scroll/DOM state restoration
- Rewrites the bootstrap and client handler to eliminate the white flash that plagued the previous implementation
- Simplifies Svelte window globals from `__SVELTE_HMR_UPDATE__` + `__SVELTE_PROPS__` + complex component type to just `__SVELTE_COMPONENT__` + `__SVELTE_UNMOUNT__`

## How It Works

### Bootstrap (`compileSvelte.ts`)

The generated index file now has two paths:

- **Initial load**: `hydrate()` attaches to server-rendered HTML (same as before)
- **HMR update**: `unmount()` the old component, then `mount()` the new one with merged props — all synchronous, so the browser never gets a chance to repaint between teardown and mount (no white flash)

State flows through `window.__HMR_PRESERVED_STATE__` with a `sessionStorage` fallback (`__SVELTE_HMR_STATE__`). The bootstrap reads preserved state, merges it into initial props, mounts, then clears the state.

### Client Handler (`handlers/svelte.ts`)

On a WebSocket `svelte-update` message:

1. **CSS-only path** — swaps the `<link>` tag in-place (no remount)
2. **Full update path**:
   - Saves DOM state (`<details>` open/closed, `<input>` values) and scroll position
   - Extracts component state from the DOM (e.g. parses counter value from button text, since Svelte 5 `$state` is not externally accessible)
   - Sets `window.__HMR_PRESERVED_STATE__` + sessionStorage backup
   - Pre-swaps CSS to prevent FOUC
   - `import()`s the new module (cache-busted) — this triggers the bootstrap above
   - Restores DOM state and scroll in `.then()`

The handler deliberately does **not** call `unmount()` or set `innerHTML` — that's the bootstrap's job. This avoids the double-unmount error and duplicate-content bug that caused the white flash.

### Server (`rebuildTrigger.ts`)

Simplified the Svelte update broadcast:
- Removed `clientModuleUrl` and `hmrId` fields (the client handler resolves the index path from the manifest)
- Added `cssUrl`, `cssBaseName`, and `updateType` fields for CSS-only detection

### Type Cleanup

- `__SVELTE_COMPONENT__` simplified to `Record<string, unknown>` (no more `$destroy`/`unmount` method types — Svelte 5 uses the standalone `unmount()` function)
- Added `__SVELTE_UNMOUNT__` as a closure that captures the current component instance
- Removed `__SVELTE_HMR_UPDATE__` flag and `__SVELTE_PROPS__` (no longer needed)
- Removed `import.meta.hot` HMR wrapper from compiled client components (the bootstrap handles everything)

## Files Changed

| File | Change |
|------|--------|
| `src/build/compileSvelte.ts` | Rewrote bootstrap: hydrate/mount branching, `__SVELTE_UNMOUNT__` closure, sessionStorage fallback, removed `import.meta.hot` wrapper |
| `src/dev/client/handlers/svelte.ts` | Rewrote handler: DOM/scroll state save/restore, CSS swap helper, removed unmount + innerHTML manipulation |
| `src/dev/rebuildTrigger.ts` | Simplified Svelte broadcast payload (dropped `hmrId`, `clientModuleUrl`; added `cssUrl`, `cssBaseName`, `updateType`) |
| `src/dev/client/types.ts` | Updated `Window` interface for new Svelte globals |
| `src/dev/types/window-globals.ts` | Updated `Window` interface for new Svelte globals |
| `src/dev/types/messages.ts` | Added `cssUrl`, `cssBaseName`, `updateType` to `SvelteUpdateMessage` |

## Test Plan

- [ ] `bun run build` succeeds
- [ ] Start dev server, navigate to `/svelte`
- [ ] Click counter to increment, save a `.svelte` file edit — counter value preserved, **no white flash**
- [ ] Edit only CSS in a `.svelte` file — styles update without component remount
- [ ] Scroll down on a long page, trigger HMR — scroll position preserved
- [ ] Open a `<details>` element, trigger HMR — stays open
- [ ] Production build (`NODE_ENV=production`) — no HMR code in output, hydration works normally