### PR TITLE
Static Plugin Wrapper for Path Sanitization into @elysiaja/static

### DIFF
--- a/example/server.ts
+++ b/example/server.ts
@@ -1,4 +1,4 @@
-import { staticPlugin } from '@elysiajs/static';
+
 import { Elysia } from 'elysia';
 import { scopedState } from 'elysia-scoped-state';
 import { generateHeadElement } from '../src/utils/generateHeadElement';
@@ -14,7 +14,8 @@ import {
 	handleHTMLPageRequest,
 	handleHTMXPageRequest,
 	handleReactPageRequest,
-	hmr
+	hmr,
+	staticPlugin
 } from '../src';
 import { networking } from '../src/plugins/networking';
 import { handleVuePageRequest } from '../src/vue';

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,3 +1,4 @@
 export * from './pageRouter';
 export * from './hmr';
 export * from './networking';
+export * from './staticPlugin';

--- a/src/plugins/staticPlugin.ts
+++ b/src/plugins/staticPlugin.ts
@@ -1,0 +1,18 @@
+import { staticPlugin as elysiaStaticPlugin } from '@elysiajs/static';
+
+/**
+ * A wrapper around @elysiajs/static that sanitizes paths.
+ * The upstream plugin has a bug where leading './' in paths results in failed matching
+ * for nested directory files (e.g. ./example/build vs example/build).
+ */
+export const staticPlugin = (
+    options?: Parameters<typeof elysiaStaticPlugin>[0]
+) => {
+    const safeOptions = { ...options };
+
+    if (safeOptions.assets?.startsWith('./')) {
+        safeOptions.assets = safeOptions.assets.slice(2);
+    }
+
+    return elysiaStaticPlugin(safeOptions);
+};


### PR DESCRIPTION
# Fix: Automatically sanitize static assets path to prevent 404s for subdirectories

## Description
This PR addresses an issue where client-side framework scripts (React, Vue, Svelte, etc.) would fail to load in production due to them returning a `404 Not Found` error. 

The root cause of this issue stems from a quirk in the `@elysiajs/static` plugin when processing paths that include a leading `./` (e.g., `./example/build`). While files at the root of the build directory were served correctly, any files within nested subdirectories (such as `/react/indexes/ReactExample.js`) would fail to match the path resolution and result in a 404 error.

To provide a seamless developer experience, we've introduced a custom `staticPlugin` wrapper in `absolutejs` (`src/plugins/staticPlugin.ts`) that intercepts the options and automatically strips any leading `./` from the `assets` property before passing it to the underlying `@elysiajs/static` plugin. 

## Changes Made
- **`src/plugins/staticPlugin.ts`**: Introduced a wrapper plugin around `@elysiajs/static` that sanitizes the `assets` path configuration.
- **`src/plugins/index.ts`**: Exported the new `staticPlugin` wrapper so it's readily available from the core framework.
- **`example/server.ts`**: Updated the example application to consume `staticPlugin` directly from `absolutejs` rather than `@elysiajs/static`, proving that leading `./` paths are now correctly handled in production.

## Testing
1. Built the example app via `bun run build`.
2. Started the production server using `bun run start`.
3. Verified that the JS chunks in nested directories (e.g. `http://localhost:3000/react/indexes/ReactExample...js`) are successfully returning `200 OK`.
4. Verified that framework-specific client-side hydrations (such as the counter button) now successfully load and function in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved a bug affecting static asset serving in nested directories. The static plugin now properly sanitizes asset paths before processing, ensuring reliable file delivery regardless of path formatting. This improves overall application stability and eliminates potential path-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->