### PR TITLE
feat(dev): self-hosted reverse tunnel for public webhook ingress

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -106,6 +106,10 @@ if (command === 'dev') {
 	sendTelemetryEvent('cli:command', { command });
 	const { setupMkcert } = await import('../dev/devCert');
 	setupMkcert();
+} else if (command === 'tunnel-relay') {
+	sendTelemetryEvent('cli:command', { command });
+	const { tunnelRelay } = await import('./scripts/tunnelRelay');
+	tunnelRelay();
 } else {
 	const message = command
 		? `Unknown command: ${command}`
@@ -133,5 +137,8 @@ if (command === 'dev') {
 	console.error('  prettier      Run Prettier check (cached)');
 	console.error('  typecheck     Run type checkers for all frameworks');
 	console.error('  telemetry     Manage anonymous telemetry');
+	console.error(
+		'  tunnel-relay  Run the public reverse-tunnel relay (for webhook dev)'
+	);
 	process.exit(1);
 }

--- a/src/cli/scripts/dev.ts
+++ b/src/cli/scripts/dev.ts
@@ -10,6 +10,7 @@ import {
 	SIGINT_EXIT_CODE,
 	SIGTERM_EXIT_CODE
 } from '../../constants';
+import { startTunnelClient } from '../../dev/tunnel/client';
 import { formatTimestamp } from '../../utils/startupBanner';
 import { createInteractiveHandler } from '../interactive';
 import { sendTelemetryEvent } from '../telemetryEvent';
@@ -143,6 +144,7 @@ type ResolvedDevConfig = {
 	strictPort: boolean;
 	host: string;
 	https: boolean;
+	tunnel?: { relay: string; token: string };
 };
 
 /** Resolve dev-server settings with env-var precedence over config file.
@@ -155,23 +157,31 @@ const resolveDevConfig = (
 				strictPort?: boolean;
 				host?: string;
 				https?: boolean;
+				tunnel?: { relay?: string; token?: string };
 		  }
 		| undefined
-): ResolvedDevConfig => ({
-	port:
-		Number(env.ABSOLUTE_PORT) ||
-		Number(env.PORT) ||
-		configDev?.port ||
-		DEFAULT_PORT,
-	portRange:
-		Number(env.ABSOLUTE_PORT_RANGE) ||
-		configDev?.portRange ||
-		DEFAULT_PORT_RANGE,
-	strictPort:
-		env.ABSOLUTE_STRICT_PORT === 'true' || configDev?.strictPort === true,
-	host: env.ABSOLUTE_HOST ?? configDev?.host ?? 'localhost',
-	https: env.ABSOLUTE_HTTPS === 'true' || configDev?.https === true
-});
+): ResolvedDevConfig => {
+	const relay = env.ABSOLUTE_TUNNEL_RELAY ?? configDev?.tunnel?.relay;
+	const token = env.ABSOLUTE_TUNNEL_TOKEN ?? configDev?.tunnel?.token;
+
+	return {
+		host: env.ABSOLUTE_HOST ?? configDev?.host ?? 'localhost',
+		https: env.ABSOLUTE_HTTPS === 'true' || configDev?.https === true,
+		port:
+			Number(env.ABSOLUTE_PORT) ||
+			Number(env.PORT) ||
+			configDev?.port ||
+			DEFAULT_PORT,
+		portRange:
+			Number(env.ABSOLUTE_PORT_RANGE) ||
+			configDev?.portRange ||
+			DEFAULT_PORT_RANGE,
+		strictPort:
+			env.ABSOLUTE_STRICT_PORT === 'true' ||
+			configDev?.strictPort === true,
+		...(relay && token ? { tunnel: { relay, token } } : {})
+	};
+};
 
 export const dev = async (serverEntry: string, configPath?: string) => {
 	let httpsEnabled = false;
@@ -221,7 +231,7 @@ export const dev = async (serverEntry: string, configPath?: string) => {
 		console.error(cliTag('\x1b[31m', String(err.message ?? err)));
 		process.exit(1);
 	});
-	let port = initialPortProbe.port;
+	let {port} = initialPortProbe;
 	if (initialPortProbe.fellBack) {
 		const displayHost =
 			resolvedDev.host === '0.0.0.0' ? 'localhost' : resolvedDev.host;
@@ -286,11 +296,26 @@ export const dev = async (serverEntry: string, configPath?: string) => {
 	let interactive: InteractiveHandler | null = null;
 
 	let serverReady = false;
+	let tunnelClient: { close(): void } | null = null;
+
+	// Once the dev server is up, dial the reverse-tunnel relay (if configured)
+	// so public webhooks reach this machine. Started once; survives HMR.
+	const startTunnelIfConfigured = () => {
+		if (tunnelClient || !resolvedDev.tunnel) return;
+		tunnelClient = startTunnelClient({
+			localOrigin: `http://localhost:${port}`,
+			relayUrl: resolvedDev.tunnel.relay,
+			token: resolvedDev.tunnel.token,
+			onReady: (publicUrl) =>
+				process.stdout.write(`  \x1b[32m➜\x1b[0m  \x1b[1mPublic:\x1b[0m  ${publicUrl}/\n`)
+		});
+	};
 
 	const checkServerReady = (value: Buffer) => {
 		const chunk = value.toString();
 		if (!chunk.includes('Local:')) return;
 		serverReady = true;
+		startTunnelIfConfigured();
 		interactive?.showPrompt();
 	};
 
@@ -395,6 +420,7 @@ export const dev = async (serverEntry: string, configPath?: string) => {
 				strictPort: dev.strictPort
 			}).catch((err) => {
 				console.error(cliTag('\x1b[31m', String(err.message ?? err)));
+
 				return undefined;
 			});
 			if (probe && probe.port !== port) {
@@ -451,6 +477,7 @@ export const dev = async (serverEntry: string, configPath?: string) => {
 				merged[key] = val;
 			}
 		}
+
 		return merged;
 	};
 
@@ -651,6 +678,7 @@ export const dev = async (serverEntry: string, configPath?: string) => {
 					if (event === 'rename') {
 						void recoveryScan();
 					}
+
 					return;
 				}
 				handleCandidate(filename);
@@ -730,6 +758,7 @@ export const dev = async (serverEntry: string, configPath?: string) => {
 			entry: serverEntry
 		});
 		if (interactive) interactive.dispose();
+		tunnelClient?.close();
 		if (paused) sendSignal('SIGCONT');
 		killChildTree('SIGTERM');
 		await new Promise<void>((res) => {

--- a/src/cli/scripts/tunnelRelay.ts
+++ b/src/cli/scripts/tunnelRelay.ts
@@ -1,0 +1,24 @@
+import { startTunnelRelay } from '../../dev/tunnel/relay';
+
+/**
+ * `absolute tunnel-relay` — run the public reverse-tunnel relay (typically on a
+ * small always-on host like a DO App Platform service). Dev machines connect to
+ * it with `dev: { tunnel: { relay, token } }`. Reads:
+ *   - PORT (App Platform injects this; default 8787)
+ *   - ABSOLUTE_TUNNEL_TOKEN (required shared secret)
+ *   - ABSOLUTE_TUNNEL_PUBLIC_URL (optional; the relay's public base URL)
+ */
+export const tunnelRelay = () => {
+	const token = process.env.ABSOLUTE_TUNNEL_TOKEN;
+	if (!token) {
+		console.error('[tunnel-relay] ABSOLUTE_TUNNEL_TOKEN is required.');
+		process.exit(1);
+	}
+
+	startTunnelRelay({
+		port: Number(process.env.PORT) || undefined,
+		publicUrl: process.env.ABSOLUTE_TUNNEL_PUBLIC_URL,
+		token
+	});
+	// Bun.serve keeps the process alive; nothing else to do.
+};

--- a/src/dev/tunnel/client.ts
+++ b/src/dev/tunnel/client.ts
@@ -1,0 +1,202 @@
+import {
+	decodeTunnelMessage,
+	encodeTunnelMessage,
+	TUNNEL_CONTROL_PATH,
+	TUNNEL_FORWARDED_HOST_HEADER,
+	type TunnelResponseMessage,
+	type TunnelServerMessage,
+	type TunnelWsDataMessage
+} from './protocol';
+
+type LocalWsEntry = {
+	ws: WebSocket;
+	ready: boolean;
+	/** Frames from the relay that arrived before the local WS opened. */
+	pending: Array<{ bytes: Buffer; binary: boolean }>;
+};
+
+type TunnelClientOptions = {
+	/** Public relay base URL, e.g. `https://my-relay.ondigitalocean.app`. */
+	relayUrl: string;
+	/** Shared secret matching the relay's token. */
+	token: string;
+	/** Local app origin to replay requests against, e.g. `http://localhost:3000`. */
+	localOrigin: string;
+	/** Called once the relay confirms the public URL is live. */
+	onReady?: (publicUrl: string) => void;
+};
+
+const RECONNECT_DELAY_MS = 2_000;
+
+const controlSocketUrl = (relayUrl: string, token: string) => {
+	const url = new URL(relayUrl);
+	url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+	url.pathname = TUNNEL_CONTROL_PATH;
+	url.search = `?token=${encodeURIComponent(token)}`;
+
+	return url.toString();
+};
+
+// Hop-by-hop / relay-injected headers that must not be replayed to the local app.
+const STRIPPED_REQUEST_HEADERS = new Set(['host', 'connection', 'content-length', TUNNEL_FORWARDED_HOST_HEADER]);
+
+/**
+ * Start the dev-side tunnel client. Dials the relay's control socket and
+ * replays each forwarded request against the local app, streaming responses
+ * back. Auto-reconnects so an HMR restart or a relay blip self-heals.
+ */
+export const startTunnelClient = (options: TunnelClientOptions) => {
+	const publicUrl = options.relayUrl.replace(/\/$/, '');
+	const localWsOrigin = options.localOrigin.replace(/^http/, 'ws');
+	let socket: WebSocket | null = null;
+	let closed = false;
+	let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	const localSockets = new Map<string, LocalWsEntry>();
+
+	const sendFrameToRelay = (id: string, data: string | Buffer, binary: boolean) => {
+		const bytes = typeof data === 'string' ? Buffer.from(data, 'utf8') : data;
+		const message: TunnelWsDataMessage = {
+			binary,
+			dataBase64: bytes.toString('base64'),
+			id,
+			type: 'ws_data'
+		};
+		socket?.send(encodeTunnelMessage(message));
+	};
+
+	// A public WS reached the relay; open the matching local WS and pipe frames.
+	const openLocalWs = (id: string, url: string) => {
+		const local = new WebSocket(`${localWsOrigin}${url}`);
+		local.binaryType = 'arraybuffer';
+		const entry: LocalWsEntry = { pending: [], ready: false, ws: local };
+		localSockets.set(id, entry);
+
+		local.addEventListener('open', () => {
+			entry.ready = true;
+			socket?.send(encodeTunnelMessage({ id, ok: true, type: 'ws_open_ack' }));
+			for (const frame of entry.pending) {
+				local.send(frame.binary ? frame.bytes : frame.bytes.toString('utf8'));
+			}
+			entry.pending = [];
+		});
+		local.addEventListener('message', (event) => {
+			if (typeof event.data === 'string') {
+				sendFrameToRelay(id, event.data, false);
+			} else if (event.data instanceof ArrayBuffer) {
+				sendFrameToRelay(id, Buffer.from(event.data), true);
+			}
+		});
+		local.addEventListener('close', (event) => {
+			localSockets.delete(id);
+			socket?.send(encodeTunnelMessage({ code: event.code, id, type: 'ws_close' }));
+		});
+		local.addEventListener('error', () => {
+			if (!entry.ready) {
+				socket?.send(
+					encodeTunnelMessage({ error: 'local ws failed', id, ok: false, type: 'ws_open_ack' })
+				);
+			}
+		});
+	};
+
+	const forwardFrameToLocal = (message: TunnelWsDataMessage) => {
+		const entry = localSockets.get(message.id);
+		if (!entry) return;
+		const bytes = Buffer.from(message.dataBase64, 'base64');
+		if (!entry.ready) {
+			entry.pending.push({ binary: message.binary, bytes });
+
+			return;
+		}
+		entry.ws.send(message.binary ? bytes : bytes.toString('utf8'));
+	};
+
+	const handleRequest = async (message: Extract<TunnelServerMessage, { type: 'request' }>) => {
+		const headers: Record<string, string> = {};
+		for (const [key, value] of Object.entries(message.headers)) {
+			if (!STRIPPED_REQUEST_HEADERS.has(key.toLowerCase())) headers[key] = value;
+		}
+		try {
+			const response = await fetch(`${options.localOrigin}${message.url}`, {
+				body: message.bodyBase64 ? Buffer.from(message.bodyBase64, 'base64') : undefined,
+				headers,
+				method: message.method,
+				redirect: 'manual'
+			});
+			const bodyBytes = new Uint8Array(await response.arrayBuffer());
+			const responseHeaders: Record<string, string> = {};
+			response.headers.forEach((value, key) => {
+				responseHeaders[key] = value;
+			});
+			const reply: TunnelResponseMessage = {
+				headers: responseHeaders,
+				id: message.id,
+				status: response.status,
+				type: 'response',
+				...(bodyBytes.length > 0 ? { bodyBase64: Buffer.from(bodyBytes).toString('base64') } : {})
+			};
+			socket?.send(encodeTunnelMessage(reply));
+		} catch (error) {
+			socket?.send(
+				encodeTunnelMessage({
+					id: message.id,
+					message: error instanceof Error ? error.message : String(error),
+					type: 'error'
+				})
+			);
+		}
+	};
+
+	const connect = () => {
+		if (closed) return;
+		socket = new WebSocket(controlSocketUrl(options.relayUrl, options.token));
+
+		socket.addEventListener('message', (event) => {
+			const message = decodeTunnelMessage(String(event.data));
+			if (!message) return;
+			switch (message.type) {
+				case 'request':
+					void handleRequest(message);
+					break;
+				case 'ready':
+					options.onReady?.(publicUrl);
+					break;
+				case 'ping':
+					socket?.send(encodeTunnelMessage({ type: 'pong' }));
+					break;
+				case 'ws_open':
+					openLocalWs(message.id, message.url);
+					break;
+				case 'ws_data':
+					forwardFrameToLocal(message);
+					break;
+				case 'ws_close':
+					localSockets.get(message.id)?.ws.close();
+					localSockets.delete(message.id);
+					break;
+				default:
+					break;
+			}
+		});
+
+		socket.addEventListener('close', () => {
+			if (closed) return;
+			reconnectTimer = setTimeout(connect, RECONNECT_DELAY_MS);
+		});
+
+		socket.addEventListener('error', () => {
+			// `close` fires after `error`; reconnect is handled there.
+		});
+	};
+
+	connect();
+
+	return {
+		publicUrl,
+		close() {
+			closed = true;
+			if (reconnectTimer) clearTimeout(reconnectTimer);
+			socket?.close();
+		}
+	};
+};

--- a/src/dev/tunnel/protocol.ts
+++ b/src/dev/tunnel/protocol.ts
@@ -1,0 +1,122 @@
+/**
+ * Reverse-tunnel wire protocol (pure Bun, no third-party deps).
+ *
+ * A dev machine behind NAT cannot accept inbound connections, so the dev
+ * `client` dials OUT to a public `relay` over a single control WebSocket. The
+ * relay receives public HTTP requests and forwards each one down that socket;
+ * the client replays it against the local app and sends the response back.
+ *
+ * Stage 1 covers HTTP request/response (webhooks). WebSocket passthrough for
+ * telephony media streams is layered on later with additional message types.
+ */
+
+/** Control-channel path the client connects to on the relay. */
+export const TUNNEL_CONTROL_PATH = '/__abs_tunnel/control';
+
+/** Header the relay strips/sets; lets the app know its public origin. */
+export const TUNNEL_FORWARDED_HOST_HEADER = 'x-absolute-tunnel-host';
+
+/** A forwarded HTTP request (relay → client). Body is base64 (binary-safe). */
+export type TunnelRequestMessage = {
+	type: 'request';
+	id: string;
+	method: string;
+	/** Path + query, e.g. `/v1/sms/intake?x=1`. */
+	url: string;
+	headers: Record<string, string>;
+	bodyBase64?: string;
+};
+
+/** The client's response to a forwarded request (client → relay). */
+export type TunnelResponseMessage = {
+	type: 'response';
+	id: string;
+	status: number;
+	headers: Record<string, string>;
+	bodyBase64?: string;
+};
+
+/** Client could not produce a response (local app down, fetch threw). */
+export type TunnelErrorMessage = {
+	type: 'error';
+	id: string;
+	message: string;
+};
+
+/** Sent by the relay right after a successful auth handshake. */
+export type TunnelReadyMessage = {
+	type: 'ready';
+	/** Public base URL the relay is reachable at, e.g. `https://x.app`. */
+	publicUrl: string;
+};
+
+// --- WebSocket passthrough (Stage 2) -----------------------------------------
+// A public WebSocket (e.g. a Twilio Media Stream) is tunneled by id over the
+// same control channel: the relay asks the client to open a matching local WS,
+// then both sides forward frames tagged with that id until either end closes.
+
+/** A public WS connection opened; client should dial the local app (relay → client). */
+export type TunnelWsOpenMessage = {
+	type: 'ws_open';
+	id: string;
+	/** Path + query of the upgraded request. */
+	url: string;
+	headers: Record<string, string>;
+};
+
+/** Result of the client opening the local WS (client → relay). */
+export type TunnelWsOpenAckMessage = {
+	type: 'ws_open_ack';
+	id: string;
+	ok: boolean;
+	error?: string;
+};
+
+/** One WS frame, either direction. Binary frames are base64. */
+export type TunnelWsDataMessage = {
+	type: 'ws_data';
+	id: string;
+	dataBase64: string;
+	binary: boolean;
+};
+
+/** A WS closed, either direction. */
+export type TunnelWsCloseMessage = {
+	type: 'ws_close';
+	id: string;
+	code?: number;
+	reason?: string;
+};
+
+/** App-level keepalive (either direction). */
+export type TunnelPingMessage = { type: 'ping' };
+export type TunnelPongMessage = { type: 'pong' };
+
+export type TunnelClientMessage =
+	| TunnelResponseMessage
+	| TunnelErrorMessage
+	| TunnelWsOpenAckMessage
+	| TunnelWsDataMessage
+	| TunnelWsCloseMessage
+	| TunnelPongMessage
+	| TunnelPingMessage;
+export type TunnelServerMessage =
+	| TunnelRequestMessage
+	| TunnelReadyMessage
+	| TunnelWsOpenMessage
+	| TunnelWsDataMessage
+	| TunnelWsCloseMessage
+	| TunnelPingMessage
+	| TunnelPongMessage;
+
+export const decodeTunnelMessage = (raw: string) => {
+	try {
+		const parsed: TunnelClientMessage | TunnelServerMessage = JSON.parse(raw);
+
+		return parsed;
+	} catch {
+		return null;
+	}
+};
+export const encodeTunnelMessage = (message: TunnelClientMessage | TunnelServerMessage) =>
+	JSON.stringify(message);

--- a/src/dev/tunnel/relay.ts
+++ b/src/dev/tunnel/relay.ts
@@ -1,0 +1,227 @@
+import type { ServerWebSocket } from 'bun';
+import {
+	decodeTunnelMessage,
+	encodeTunnelMessage,
+	TUNNEL_CONTROL_PATH,
+	TUNNEL_FORWARDED_HOST_HEADER,
+	type TunnelClientMessage,
+	type TunnelRequestMessage
+} from './protocol';
+
+type RelayOptions = {
+	/** Port the relay listens on (App Platform injects PORT). */
+	port?: number;
+	/** Shared secret the dev client must present (?token=). */
+	token: string;
+	/** Public base URL the relay is reachable at. Falls back to the request
+	 *  origin when omitted (App Platform: set APP_URL or pass explicitly). */
+	publicUrl?: string;
+	/** How long to wait for the dev client to answer a forwarded request. */
+	requestTimeoutMs?: number;
+};
+
+type ControlSocketData = { control: true };
+type PublicSocketData = {
+	control: false;
+	id: string;
+	url: string;
+	headers: Record<string, string>;
+};
+type SocketData = ControlSocketData | PublicSocketData;
+
+const DEFAULT_RELAY_PORT = 8787;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+const headersToObject = (headers: Headers) => {
+	const out: Record<string, string> = {};
+	headers.forEach((value, key) => {
+		out[key] = value;
+	});
+
+	return out;
+};
+
+/**
+ * Start the public reverse-tunnel relay. Holds one dev-client control socket
+ * and forwards every other inbound HTTP request — and public WebSocket — down
+ * it. Single-tenant: the shared `token` gates the control channel.
+ */
+export const startTunnelRelay = (options: RelayOptions) => {
+	const port = options.port ?? (Number(process.env.PORT) || DEFAULT_RELAY_PORT);
+	const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+
+	let client: ServerWebSocket<SocketData> | null = null;
+	const pending = new Map<string, (message: TunnelClientMessage) => void>();
+	const publicSockets = new Map<string, ServerWebSocket<SocketData>>();
+
+	const resolvePublicUrl = (request: Request) => {
+		if (options.publicUrl) return options.publicUrl.replace(/\/$/, '');
+		const url = new URL(request.url);
+		const host = request.headers.get('x-forwarded-host') ?? url.host;
+		const proto = request.headers.get('x-forwarded-proto') ?? url.protocol.replace(':', '');
+
+		return `${proto}://${host}`;
+	};
+
+	const isWebSocketUpgrade = (request: Request) =>
+		request.headers.get('upgrade')?.toLowerCase() === 'websocket';
+
+	const server = Bun.serve<SocketData>({
+		port,
+		websocket: {
+			close(ws) {
+				if (ws.data.control) {
+					if (client === ws) client = null;
+
+					return;
+				}
+				publicSockets.delete(ws.data.id);
+				client?.send(encodeTunnelMessage({ id: ws.data.id, type: 'ws_close' }));
+			},
+			message(ws, raw) {
+				// Public socket: forward the raw frame to the dev client.
+				if (!ws.data.control) {
+					const binary = typeof raw !== 'string';
+					const bytes = typeof raw === 'string' ? Buffer.from(raw, 'utf8') : Buffer.from(raw);
+					client?.send(
+						encodeTunnelMessage({
+							binary,
+							dataBase64: bytes.toString('base64'),
+							id: ws.data.id,
+							type: 'ws_data'
+						})
+					);
+
+					return;
+				}
+
+				// Control socket: messages from the dev client.
+				const message = decodeTunnelMessage(
+					typeof raw === 'string' ? raw : raw.toString()
+				);
+				if (!message) return;
+				switch (message.type) {
+					case 'ping':
+						ws.send(encodeTunnelMessage({ type: 'pong' }));
+						break;
+					case 'response':
+					case 'error':
+						pending.get(message.id)?.(message);
+						break;
+					case 'ws_open_ack':
+						if (!message.ok) publicSockets.get(message.id)?.close();
+						break;
+					case 'ws_data': {
+						const target = publicSockets.get(message.id);
+						const bytes = Buffer.from(message.dataBase64, 'base64');
+						target?.send(message.binary ? bytes : bytes.toString('utf8'));
+						break;
+					}
+					case 'ws_close':
+						publicSockets.get(message.id)?.close(message.code, message.reason);
+						publicSockets.delete(message.id);
+						break;
+					default:
+						break;
+				}
+			},
+			open(ws) {
+				if (ws.data.control) {
+					// Single-tenant: a new client replaces any stale one.
+					client = ws;
+					ws.send(encodeTunnelMessage({ publicUrl: options.publicUrl ?? '', type: 'ready' }));
+
+					return;
+				}
+				// Public WS: register it and ask the dev client to open the local peer.
+				publicSockets.set(ws.data.id, ws);
+				client?.send(
+					encodeTunnelMessage({
+						headers: ws.data.headers,
+						id: ws.data.id,
+						type: 'ws_open',
+						url: ws.data.url
+					})
+				);
+			}
+		},
+		async fetch(request, srv) {
+			const url = new URL(request.url);
+
+			// Dev client connects here to open the control channel.
+			if (url.pathname === TUNNEL_CONTROL_PATH) {
+				if (url.searchParams.get('token') !== options.token) {
+					return new Response('Forbidden', { status: 403 });
+				}
+				const upgraded = srv.upgrade(request, { data: { control: true } });
+
+				return upgraded ? undefined : new Response('Upgrade failed', { status: 426 });
+			}
+
+			if (!client) {
+				return new Response('Tunnel offline: no dev client connected.', { status: 503 });
+			}
+
+			// Public WebSocket (e.g. Twilio Media Stream) → tunnel it by id.
+			if (isWebSocketUpgrade(request)) {
+				const id = crypto.randomUUID();
+				const upgraded = srv.upgrade(request, {
+					data: {
+						control: false,
+						headers: headersToObject(request.headers),
+						id,
+						url: url.pathname + url.search
+					}
+				});
+
+				return upgraded ? undefined : new Response('Upgrade failed', { status: 426 });
+			}
+
+			// Public HTTP request → forward and await the dev client's response.
+			const id = crypto.randomUUID();
+			const bodyBytes = ['GET', 'HEAD'].includes(request.method)
+				? null
+				: new Uint8Array(await request.arrayBuffer());
+			const headers = headersToObject(request.headers);
+			headers[TUNNEL_FORWARDED_HOST_HEADER] = resolvePublicUrl(request);
+
+			const message: TunnelRequestMessage = {
+				headers,
+				id,
+				method: request.method,
+				type: 'request',
+				url: url.pathname + url.search,
+				...(bodyBytes && bodyBytes.length > 0
+					? { bodyBase64: Buffer.from(bodyBytes).toString('base64') }
+					: {})
+			};
+
+			const responsePromise = new Promise<TunnelClientMessage>((resolve) => {
+				pending.set(id, resolve);
+			});
+			client.send(encodeTunnelMessage(message));
+
+			const timeout = new Promise<TunnelClientMessage>((resolve) =>
+				setTimeout(() => resolve({ id, message: 'timeout', type: 'error' }), requestTimeoutMs)
+			);
+			const result = await Promise.race([responsePromise, timeout]);
+			pending.delete(id);
+
+			if (result.type === 'error') {
+				return new Response(`Tunnel error: ${result.message}`, { status: 504 });
+			}
+			if (result.type !== 'response') {
+				return new Response('Tunnel protocol error', { status: 502 });
+			}
+
+			return new Response(
+				result.bodyBase64 ? Buffer.from(result.bodyBase64, 'base64') : null,
+				{ headers: result.headers, status: result.status }
+			);
+		}
+	});
+
+	console.info(`[tunnel-relay] listening on :${server.port} (control ${TUNNEL_CONTROL_PATH})`);
+
+	return server;
+};

--- a/templates/tunnel-relay/.do/app.yaml
+++ b/templates/tunnel-relay/.do/app.yaml
@@ -1,0 +1,24 @@
+# DigitalOcean App Platform spec for the AbsoluteJS tunnel relay.
+# Create via: doctl apps create --spec .do/app.yaml  (or paste in the DO UI).
+name: absolute-tunnel-relay
+services:
+  - name: relay
+    dockerfile_path: Dockerfile
+    # Point this at the git repo holding this template (push-to-deploy).
+    github:
+      repo: your-org/absolute-tunnel-relay
+      branch: main
+      deploy_on_push: true
+    http_port: 8080
+    instance_size_slug: basic-xxs
+    instance_count: 1
+    envs:
+      # Long random shared secret; the dev client must send the same value.
+      - key: ABSOLUTE_TUNNEL_TOKEN
+        scope: RUN_TIME
+        type: SECRET
+        value: REPLACE_WITH_A_LONG_RANDOM_SECRET
+      # The relay's own public URL (fill in after the first deploy assigns it).
+      - key: ABSOLUTE_TUNNEL_PUBLIC_URL
+        scope: RUN_TIME
+        value: https://absolute-tunnel-relay-xxxxx.ondigitalocean.app

--- a/templates/tunnel-relay/Dockerfile
+++ b/templates/tunnel-relay/Dockerfile
@@ -1,0 +1,13 @@
+# Public reverse-tunnel relay for AbsoluteJS dev (webhook ingress).
+# Deploy to any always-on host with a public HTTPS URL (e.g. DO App Platform).
+FROM oven/bun:1
+
+WORKDIR /app
+COPY package.json ./
+RUN bun install
+
+# App Platform injects PORT; the relay reads it. ABSOLUTE_TUNNEL_TOKEN is the
+# shared secret your dev machine presents. ABSOLUTE_TUNNEL_PUBLIC_URL (optional)
+# is the relay's own public base URL, used when emitting absolute links.
+EXPOSE 8080
+CMD ["bun", "run", "start"]

--- a/templates/tunnel-relay/README.md
+++ b/templates/tunnel-relay/README.md
@@ -1,0 +1,41 @@
+# AbsoluteJS tunnel relay
+
+A tiny, self-hosted public relay that lets a local `bun run dev` receive
+webhooks and WebSockets (Twilio, Stripe, OAuth callbacks) **without deploying**.
+Pure Bun, zero third-party tunnel services — you run your own relay.
+
+```
+Internet ──HTTPS/WSS──▶  relay (this app, public)  ──control WS──▶  your laptop (bun run dev)
+```
+
+## 1. Deploy the relay (DigitalOcean App Platform)
+
+1. Put this folder in its own git repo (App Platform deploys from a repo + Dockerfile).
+2. Pick a long random secret for `ABSOLUTE_TUNNEL_TOKEN` (e.g. `openssl rand -hex 32`).
+3. Create the app from `.do/app.yaml` (`doctl apps create --spec .do/app.yaml`)
+   or via the DO UI (Docker source, port 8080, set the env vars).
+4. After the first deploy DO assigns a URL like
+   `https://absolute-tunnel-relay-xxxxx.ondigitalocean.app` — set that as
+   `ABSOLUTE_TUNNEL_PUBLIC_URL` and redeploy. (Add a custom domain like
+   `tunnel.yourdomain.com` later if you want.)
+
+## 2. Point your app's dev server at it
+
+In the consuming app's `absolute.config.ts`:
+
+```ts
+export default defineConfig({
+  dev: {
+    tunnel: {
+      relay: 'https://absolute-tunnel-relay-xxxxx.ondigitalocean.app',
+      token: process.env.ABSOLUTE_TUNNEL_TOKEN // same secret as the relay
+    }
+  }
+});
+```
+
+Now `bun run dev` prints a `Public:` line — that public URL routes straight to
+your local server. Use it for your webhook provider's callback URLs.
+
+> The relay is single-tenant per token: one dev machine at a time. Give each
+> developer their own relay app (or token) if you need several.

--- a/templates/tunnel-relay/package.json
+++ b/templates/tunnel-relay/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "absolute-tunnel-relay",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "absolute tunnel-relay"
+  },
+  "dependencies": {
+    "@absolutejs/absolute": "^0.19.0-beta.1009"
+  }
+}

--- a/types/build.ts
+++ b/types/build.ts
@@ -244,6 +244,17 @@ export type BaseBuildConfig = {
 		 *  conventional source dirs (`src/`, `db/`, `assets/`, `styles/`),
 		 *  and these `watchDirs` is implicitly ignored. */
 		watchDirs?: string[];
+		/** Expose the dev server to the public internet through a self-hosted
+		 *  AbsoluteJS reverse-tunnel relay (for webhooks: Twilio, Stripe, OAuth).
+		 *  Run the relay with `absolute tunnel-relay` on a public host; point a
+		 *  dev client at it here. Prints a `Public:` URL on start. */
+		tunnel?: {
+			/** Relay base URL, e.g. `https://my-relay.ondigitalocean.app`
+			 *  (env: ABSOLUTE_TUNNEL_RELAY). */
+			relay?: string;
+			/** Shared secret matching the relay's token (env: ABSOLUTE_TUNNEL_TOKEN). */
+			token?: string;
+		};
 		devtools?: {
 			// Override the workspace root reported to Chrome DevTools.
 			projectRoot?: string;


### PR DESCRIPTION
Adds an opt-in, self-hosted reverse tunnel to `absolute dev` so a local server can receive public webhooks/WebSockets (Twilio, Stripe, OAuth) **without deploying** — no third-party tunnel service.

## What
- **`src/dev/tunnel/`** (pure Bun, zero deps): `relay.ts` (public, token-gated control WS + HTTP forward + WS multiplexing), `client.ts` (dev-side, replays to local app, auto-reconnect), `protocol.ts`.
- **`absolute tunnel-relay`** CLI — runs the relay (Docker entrypoint; reads `PORT`, `ABSOLUTE_TUNNEL_TOKEN`, `ABSOLUTE_TUNNEL_PUBLIC_URL`).
- **`dev.tunnel: { relay, token }`** config + `dev.ts` integration — dials on start, prints a `Public:` URL, closes on exit.
- **`templates/tunnel-relay/`** — Dockerfile + DO App Platform spec + README.

## Verified
HTTP forwarding + WebSocket-over-WebSocket passthrough proven end-to-end locally (incl. against a real Twilio TwiML + SMS webhook). Framework typecheck clean, tunnel files lint-clean, `bun run build` succeeds, built `absolute tunnel-relay` binds.

Note: `package.json` (zone.js peer-dep / version) intentionally left out of this branch — that's separate WIP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `tunnel-relay` CLI command to operate a public relay server
  * Dev server now supports reverse tunneling to automatically publish a public URL
  * Added DigitalOcean App Platform deployment templates for relay infrastructure
  * New `dev.tunnel` configuration options to connect dev servers to relay endpoints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/absolutejs/absolutejs/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->